### PR TITLE
remove table_exists? call so db connection is not established at app boot

### DIFF
--- a/has_metrics.gemspec
+++ b/has_metrics.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "has_metrics"
-  s.version = "0.2.0"
+  s.version = "0.2.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Allan Grant"]

--- a/lib/has_metrics/metrics.rb
+++ b/lib/has_metrics/metrics.rb
@@ -15,14 +15,8 @@ module Metrics
     end
 
     base.class_eval do
-      if klass.table_exists?
-        @metrics_class = klass
-        has_one :metrics, :class_name => klass_name, :foreign_key => 'id', :dependent => :destroy
-      else
-        @object_class = base
-        @metrics_class = base
-        base.extend(Metrics::MetricsClass)
-      end
+      @metrics_class = klass
+      has_one :metrics, :class_name => klass_name, :foreign_key => 'id', :dependent => :destroy
 
       def metrics
         @metrics ||= begin


### PR DESCRIPTION
That call to `table_exists?` was causing the app to establish a db connection when the app boots. Puma would never close this connection, and instead of passing it on to the incoming request(s), it would then establish a new connection, resulting in 2 persistent db connections per web server.

I just removed the branching logic because in our use case this conditional should always return true.
cc @wnadeau 